### PR TITLE
Adds a new administrator setting to choose the template category.

### DIFF
--- a/db/install.php
+++ b/db/install.php
@@ -1,0 +1,61 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * The installation script.
+ *
+ * @package     local_course_templates
+ * @copyright   2021 Andrew Caya <andrewscaya@yahoo.ca>
+ * @author      Andrew Caya
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die;
+
+/**
+ * Sets some database values upon plugin installation.
+ *
+ * @return bool
+ * @throws dml_exception
+ * @throws moodle_exception
+ */
+function xmldb_local_course_templates_install() {
+    global $CFG, $DB;
+
+    require_once($CFG->dirroot . DIRECTORY_SEPARATOR . 'course' . DIRECTORY_SEPARATOR . 'lib.php');
+
+    // Check if the 'Course templates' category exists and if not, create it.
+    $templatecategory = $DB->get_record('course_categories', array('name' => 'Course templates'));
+
+    if ($templatecategory === false) {
+        $dataobject = new stdClass();
+        $dataobject->name = 'Course templates';
+        $dataobject->idnumber = '';
+        $dataobject->description = 'Category containing course templates';
+        $dataobject->descriptionformat = 0;
+        $dataobject->parent = 0;
+        $dataobject->sortorder = 20000;
+        $dataobject->coursecount = 0;
+        $dataobject->visible = 1;
+        $dataobject->visibleold = 1;
+        $dataobject->timemodified = time();
+
+        // Refreshing caches through the Event API.
+        core_course_category::create($dataobject);
+    }
+
+    return true;
+}

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -1,0 +1,81 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * The upgrade script.
+ *
+ * @package     local_course_templates
+ * @copyright   2021 Andrew Caya <andrewscaya@yahoo.ca>
+ * @author      Andrew Caya
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die;
+
+/**
+ * Sets some database values upon plugin upgrade.
+ *
+ * @param int $oldversion
+ * @return bool
+ * @throws dml_exception
+ * @throws moodle_exception
+ */
+function xmldb_local_course_templates_upgrade($oldversion) {
+    if ($oldversion < 2021121500) {
+        global $CFG, $DB;
+
+        require_once($CFG->dirroot . DIRECTORY_SEPARATOR . 'course' . DIRECTORY_SEPARATOR . 'lib.php');
+
+        // Check if the 'Course templates' category exists and if not, create it.
+        $templatecategory = $DB->get_record('course_categories', array('name' => 'Course templates'));
+
+        if ($templatecategory === false) {
+            $dataobject = new stdClass();
+            $dataobject->name = 'Course templates';
+            $dataobject->description = 'Category containing course templates';
+            $dataobject->descriptionformat = 0;
+            $dataobject->parent = 0;
+            $dataobject->sortorder = 20000;
+            $dataobject->coursecount = 0;
+            $dataobject->visible = 1;
+            $dataobject->visibleold = 1;
+            $dataobject->timemodified = time();
+
+            // Refreshing caches through the Event API.
+            $templatecategory = core_course_category::create($dataobject);
+        }
+
+        // Set the default administrator setting to 'Course templates'.
+        $id = $templatecategory->id;
+
+        $dataobject2 = new stdClass();
+        $dataobject2->plugin = 'local_course_templates';
+        $dataobject2->name = 'namecategory';
+        $dataobject2->value = $id;
+
+        $adminsetting = $DB->get_record('config_plugins', array('plugin' => 'local_course_templates', 'name' => 'namecategory'));
+
+        if ($adminsetting !== false) {
+            $dataobject2->id = $adminsetting->id;
+
+            $DB->update_record('config_plugins', $dataobject2, false);
+        } else {
+            $DB->insert_record('config_plugins', $dataobject2, false);
+        }
+    }
+
+    return true;
+}

--- a/lang/en/local_course_templates.php
+++ b/lang/en/local_course_templates.php
@@ -46,6 +46,9 @@ $string['enddate'] = 'End date';
 $string['location'] = 'Location';
 $string['datetime'] = 'Date and time';
 
+$string['namecategory'] = 'Category';
+$string['namecategorydescription'] = 'Please choose the category that you want to use for the course templates';
+
 $string['jumpto'] = 'Jump to';
 $string['jumpto_coursepage'] = 'Course page ';
 $string['jumpto_coursesettingspage'] = 'Course settings page';

--- a/lib.php
+++ b/lib.php
@@ -33,7 +33,10 @@ defined('MOODLE_INTERNAL') || die;
 function get_template_list() {
     global $CFG, $USER, $DB;
 
-    $sql = "select id,fullname from {course} where category = (select id from {course_categories} where name='Course templates')";
+    $namecategoryid = get_config('local_course_templates', 'namecategory');
+
+    $sql = "select id, fullname from {course} where category = (select id from {course_categories} where id='$namecategoryid')";
+
     return $DB->get_records_sql($sql);
 }
 

--- a/settings.php
+++ b/settings.php
@@ -24,9 +24,9 @@
 
 defined('MOODLE_INTERNAL') || die;
 
+global $DB;
 
 if ($hassiteconfig) {
-
     $ADMIN->add(
         'courses',
         new admin_externalpage(
@@ -37,22 +37,46 @@ if ($hassiteconfig) {
     );
 
     $settings = new admin_settingpage('local_course_templates_settings', 'Course templates');
+
     $ADMIN->add('localplugins', $settings);
-    $options = array(
-        1 => get_string('jumpto_coursepage', 'local_course_templates'),
-        2 => get_string('jumpto_coursesettingspage', 'local_course_templates')
-    );
-    $settings->add(
-        new admin_setting_configselect(
-            'local_course_templates/jump_to',
-            get_string('jumpto', 'local_course_templates'),
-            '',
-            1,
-            $options
-        )
-    );
 
+    if ($ADMIN->fulltree) {
+        $default = get_config('local_course_templates', 'namecategory');
 
+        if ($default === false) {
+            $templatecategory = $DB->get_record('course_categories', array('name' => 'Course templates'));
+
+            // Set the new default administrator setting to 'Course templates' if it exists, if not default to 'Miscellaneous'.
+            if ($templatecategory !== false) {
+                $default = $templatecategory->id;
+            } else {
+                $default = 1;
+            }
+        }
+
+        $settings->add(
+            new admin_settings_coursecat_select(
+                'local_course_templates/namecategory',
+                get_string('namecategory', 'local_course_templates'),
+                get_string('namecategorydescription', 'local_course_templates'),
+                $default
+            )
+        );
+
+        $options = array(
+            1 => get_string('jumpto_coursepage', 'local_course_templates'),
+            2 => get_string('jumpto_coursesettingspage', 'local_course_templates'));
+
+        $settings->add(
+            new admin_setting_configselect(
+                'local_course_templates/jump_to',
+                get_string('jumpto', 'local_course_templates'),
+                '',
+                1,
+                $options
+            )
+        );
+    }
 }
 
 

--- a/version.php
+++ b/version.php
@@ -26,7 +26,7 @@ defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'local_course_templates';
 $plugin->cron = 0;
-$plugin->version  = 2019120800;
+$plugin->version  = 2021121500;
 $plugin->requires = 2015041700;
 $plugin->maturity = MATURITY_STABLE;
 $plugin->release = 'Course templates plugin Version 3.7-a';


### PR DESCRIPTION
This pull request adds an admin setting that allows the plugin's users to select which course category they want to use for templates.

* Standard Moodle installation procedure,
* Silent upgrade for current users ($oldversion < 2021121500),
* Adds the 'Course templates' category if none is found (applies to both installation and upgrade procedures).