### PR TITLE
28 Fix Can't find data record in course_categories

### DIFF
--- a/index.php
+++ b/index.php
@@ -35,7 +35,7 @@ $step = optional_param('step', 0, PARAM_INT);
 $cid = optional_param('cid', 0, PARAM_INT);
 $coursestatus = optional_param('status', 0, PARAM_INT);
 $courseid = optional_param('courseid', 0, PARAM_INT);
-$cateid = optional_param('cateid', 1, PARAM_INT);
+$cateid = optional_param('cateid', $CFG->defaultrequestcategory, PARAM_INT);
 
 $params = array();
 $userid = $USER->id;  // Owner of the page.


### PR DESCRIPTION
The default category was set to 1 which is the Miscellaneous category.
However there's no reason that this category must exist and it may be
deleted.  If this category had been deleted then the error "Can't find data
record in database table course_categories" would appear".  So we now
default to $CFG->defaultrequestcategory which is 1 by default but gets
changed to another category if Miscellaneous is deleted.